### PR TITLE
Add "saving" and "clear" functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+
+# MDK - Space Engineers MDK
+*.props

--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,4 @@ FodyWeavers.xsd
 
 # MDK - Space Engineers MDK
 *.props
+*.zip

--- a/All My Stuff/ManagedDisplay.cs
+++ b/All My Stuff/ManagedDisplay.cs
@@ -32,7 +32,8 @@ namespace IngameScript
             private float LineHeight = 30f;
             private float HeadingFontSize = 1.3f;
             private float RegularFontSize = 1.0f;
-            private Vector2 Position;
+            private float finalColumnWidth;
+            private Vector2 Position, _padding;
             private int WindowSize;         // Number of lines shown on screen at once after heading
             private Color HighlightColor;
             private int linesToSkip;
@@ -64,17 +65,18 @@ namespace IngameScript
 
                 surface.ContentType = ContentType.SCRIPT;
                 surface.Script = "TSS_FactionIcon";
-                Vector2 padding = surface.TextureSize * (surface.TextPadding / 100);
-                viewport = new RectangleF((surface.TextureSize - surface.SurfaceSize) / 2f + padding, surface.SurfaceSize - (2*padding));
+                _padding = surface.TextureSize * (surface.TextPadding / 100);
+                viewport = new RectangleF((surface.TextureSize - surface.SurfaceSize) / 2f + _padding, surface.SurfaceSize - (2*_padding));
                 WindowSize = ((int)((viewport.Height - 10 * scale) / LineHeight));
+
+                finalColumnWidth = HeadingFontSize * 80;
+                // that thing above is rough - this is just used to stop headings colliding, nothing serious,
+                // and is way cheaper than allocating a StringBuilder and measuring the width of the final
+                // column heading text in pixels.
             }
 
             private void AddHeading()
             {
-                float finalColumnWidth = HeadingFontSize * 80;
-                // that thing above is rough - this is just used to stop headings colliding, nothing serious,
-                // and is way cheaper than allocating a StringBuilder and measuring the width of the final
-                // column heading text in pixels.
                 if (surface.Script != "")
                 {
                     surface.Script = "";
@@ -95,7 +97,7 @@ namespace IngameScript
                     Alignment = TextAlignment.CENTER
                 });
                 Position.X += viewport.Width / 8f;
-                frame.Add(MySprite.CreateClipRect(new Rectangle((int)Position.X, (int)Position.Y, (int)(viewport.Width - Position.X - finalColumnWidth), (int)(Position.Y + HeadingHeight))));
+                frame.Add(MySprite.CreateClipRect(new Rectangle((int)Position.X, (int)Position.Y, (int)(viewport.Width - Position.X + (viewport.X - _padding.X/2) - finalColumnWidth), (int)(Position.Y + HeadingHeight))));
                 frame.Add(new MySprite()
                 {
                     Type = SpriteType.TEXT,
@@ -107,7 +109,7 @@ namespace IngameScript
                     FontId = "White"
                 });
                 frame.Add(MySprite.CreateClearClipRect());
-                Position.X = viewport.Width ;
+                Position.X = viewport.Width + viewport.X - _padding.X / 2;
                 frame.Add(new MySprite()
                 {
                     Type = SpriteType.TEXT,
@@ -118,6 +120,7 @@ namespace IngameScript
                     Alignment = TextAlignment.RIGHT,
                     FontId = "White"
                 });
+
                 Position.Y += HeadingHeight;
             }
 
@@ -131,10 +134,6 @@ namespace IngameScript
 
             private void RenderRow(Program.Item item)
             {
-                float finalColumnWidth = HeadingFontSize * 80;
-                // that thing above is rough - this is just used to stop headings colliding, nothing serious,
-                // and is way cheaper than allocating a StringBuilder and measuring the width of the final
-                // column heading text in pixels.
                 Color TextColor;
                 if (item.Amount == 0)
                 {
@@ -170,7 +169,7 @@ namespace IngameScript
                     Alignment = TextAlignment.CENTER,
                 });
                 Position.X += viewport.Width / 8f;
-                frame.Add(MySprite.CreateClipRect(new Rectangle((int)Position.X, (int)Position.Y, (int)(viewport.Width - Position.X - finalColumnWidth), (int)(Position.Y + HeadingHeight))));
+                frame.Add(MySprite.CreateClipRect(new Rectangle((int)Position.X, (int)Position.Y, (int)(viewport.Width - Position.X + (viewport.X -_padding.X / 2) - finalColumnWidth), (int)(Position.Y + HeadingHeight))));
                 frame.Add(new MySprite()
                 {
                     Type = SpriteType.TEXT,

--- a/All My Stuff/Program.cs
+++ b/All My Stuff/Program.cs
@@ -48,24 +48,14 @@ namespace IngameScript
 
         public class Item
         {
-            public Item(MyInventoryItem item, Program program, int amount = 0)
-            {
-                this.Sprite = item.Type.ToString();
-                this.Name = item.Type.SubtypeId;
-                this.ItemType = item.Type.TypeId;
-                this.Amount = amount;
-                this.NaturalName = Name;
-                this.KeyString = program.TranslateEnabled ? item.Type.TypeId.Substring(characters_to_skip).ToLower() + '/' + Name.ToLower() : "";
-            }
-
             public Item(string itemType, Program program, int amount = 0)
             {
-                this.Sprite = itemType;
-                this.Name = itemType.Substring(characters_to_skip).Split('/')[1];
-                this.ItemType = itemType.Substring(characters_to_skip).Split('/')[0]; ;
-                this.Amount = amount;
-                this.NaturalName = Name;
-                this.KeyString = program.TranslateEnabled ? ItemType.Substring(characters_to_skip).ToLower() + '/' + Name.ToLower() : "";
+                Sprite = itemType;
+                Name = itemType.Substring(characters_to_skip).Split('/')[1];
+                ItemType = itemType.Split('/')[0]; ;
+                Amount = amount;
+                NaturalName = Name;
+                KeyString = program.TranslateEnabled ? ItemType.Substring(characters_to_skip).ToLower() + '/' + Name.ToLower() : "";
             }
 
             public string KeyString;
@@ -231,7 +221,7 @@ namespace IngameScript
                             string key = item.Type.ToString();
                             if (!Stock.ContainsKey(key))
                             {
-                                Item newItem = new Item(item, this);
+                                Item newItem = new Item(item.Type.ToString(), this);
                                 newItem.NaturalName = Translation.ContainsKey(newItem.KeyString) ? Translation[newItem.KeyString] : newItem.Name;
                                 Stock.Add(key, newItem);
                             }

--- a/All My Stuff/Program.cs
+++ b/All My Stuff/Program.cs
@@ -50,12 +50,12 @@ namespace IngameScript
         {
             public Item(string itemType, Program program, int amount = 0)
             {
+                var temp = itemType.Split('/');
                 Sprite = itemType;
-                Name = itemType.Substring(characters_to_skip).Split('/')[1];
-                ItemType = itemType.Split('/')[0]; ;
+                Name = NaturalName = temp[1];
+                ItemType = temp[0];
                 Amount = amount;
-                NaturalName = Name;
-                KeyString = program.TranslateEnabled ? ItemType.Substring(characters_to_skip).ToLower() + '/' + Name.ToLower() : "";
+                KeyString = program.TranslateEnabled ? itemType.Substring(characters_to_skip).ToLower() : "";
             }
 
             public string KeyString;


### PR DESCRIPTION
Add saving functionality to allow know items to be saved on the Storage field of the programable block, to avoid "losing" data about an item if the PB is recompiled while theres no sample of this item in any cargo container

also added "clear" functionality to allow removing items with the amount equal to 0 from the storage dictionary